### PR TITLE
require Stripe through  provider

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,10 @@
 
 var angular = require('angular')
 var provider = require('./provider')
-var Stripe = window.Stripe
 
 module.exports = angular.module('angular-stripe', [
   require('angular-assert-q-constructor')
 ])
-.constant('Stripe', Stripe)
 .provider('stripe', provider)
 .run(verifyQ)
 .name

--- a/src/provider.js
+++ b/src/provider.js
@@ -4,8 +4,9 @@ var service = require('./service')
 
 module.exports = stripeProvider
 
-stripeProvider.$inject = ['Stripe']
-function stripeProvider (Stripe) {
+stripeProvider.$inject = ['$window']
+function stripeProvider ($window) {
+  var Stripe = $window.Stripe;
   if (!Stripe) throw new Error('Stripe must be available as window.Stripe')
   this.setPublishableKey = Stripe.setPublishableKey
   this.$get = service

--- a/src/service.js
+++ b/src/service.js
@@ -4,7 +4,7 @@ var stripeAsPromised = require('stripe-as-promised')
 
 module.exports = factory
 
-factory.$inject = ['Stripe', '$q']
-function factory (Stripe, $q) {
-  return stripeAsPromised(Stripe, $q)
+factory.$inject = ['$window', '$q']
+function factory ($window, $q) {
+  return stripeAsPromised($window.Stripe, $q)
 }


### PR DESCRIPTION
constants provided to a module can't be mocked, providing Stripe through the $window provider makes mocking the Stripe library easier.

I didn't build or test this since no task manager is provided.