### PR TITLE
chore(deps): update dependencies + relax angular constraints

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,6 @@
     "karma.conf.js"
   ],
   "dependencies": {
-    "angular": ">=1.3 <1.5"
+    "angular": ">=1.3 <=1.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,21 +25,21 @@
   },
   "homepage": "https://github.com/bendrucker/angular-stripe",
   "devDependencies": {
-    "angular": "~1.3.14",
-    "angular-mocks": "~1.3.14",
-    "browserify": "~10.2.4",
-    "chai": "~3.0.0",
+    "angular": "~1.4.9",
+    "angular-mocks": "~1.4.9",
+    "browserify": "~13.0.0",
+    "chai": "~3.5.0",
     "derequire": "~2.0.0",
-    "exposify": "~0.4.1",
-    "phantomjs": "~1.9.17",
-    "sinon": "~1.15.3",
+    "exposify": "~0.5.0",
+    "phantomjs": "~2.1.3",
+    "sinon": "~1.17.3",
     "sinon-chai": "~2.8.0",
-    "standard": "~4.2.1",
+    "standard": "~5.4.1",
     "stripe-debug": "~2.0.0",
-    "zuul": "~3.0.0"
+    "zuul": "~3.9.0"
   },
   "peerDependencies": {
-    "angular": ">=1.3 <1.5"
+    "angular": ">=1.3 <=1.5"
   },
   "dependencies": {
     "angular-assert-q-constructor": "~1.0.1",

--- a/test/service.js
+++ b/test/service.js
@@ -90,12 +90,9 @@ describe('stripe: Service', function () {
               err = _err_
             })
           $timeout.flush()
-          expect(err).to.contain(response.error)
+          expect(err.message).to.contain(response.error.message)
         })
       })
-
     })
-
   })
-
 })


### PR DESCRIPTION
`npm test` runs successfully. Only thing I can't be certain about is `browserify`. I've been running this against angular-1.5.0rc* fine for awhile now.