### PR TITLE
Allow Angular 1.5.x.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,6 @@
     "karma.conf.js"
   ],
   "dependencies": {
-    "angular": ">=1.3 <=1.5"
+    "angular": ">=1.3 <1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "zuul": "~3.9.0"
   },
   "peerDependencies": {
-    "angular": ">=1.3 <=1.5"
+    "angular": ">=1.3 <1.6"
   },
   "dependencies": {
     "angular-assert-q-constructor": "~1.0.1",


### PR DESCRIPTION
Now that Angular 1.5.0 is generally available, relax the constraints on Angular version. I have run `npm test` against Angular 1.5.0 and everything passes. 