### PR TITLE
Allow Angular up to versions <2.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,6 @@
     "karma.conf.js"
   ],
   "dependencies": {
-    "angular": ">=1.3 <=1.5"
+    "angular": ">=1.3 <2"
   }
 }


### PR DESCRIPTION
This is a follow up from PR #41. 

Allows `angular-stripe` to be installed alongside Angular versions below 2. 